### PR TITLE
fix text class params

### DIFF
--- a/force-app/main/default/classes/UserSignatureTest.cls
+++ b/force-app/main/default/classes/UserSignatureTest.cls
@@ -11,6 +11,6 @@ public with sharing class UserSignatureTest {
 
         insert con;
         
-        UserSignature.saveAsDocumentOnRecord('BorderCollie', con.Id, '.txt');
+        UserSignature.saveAsDocumentOnRecord(con.Id, 'BorderCollie', '.txt');
     }
 }


### PR DESCRIPTION
Updated params for test class method: `UserSignatureTest.saveAsDocumentOnRecordTest()`

From `UserSignature.saveAsDocumentOnRecord('BorderCollie', con.Id, '.txt');` =>
`UserSignature.saveAsDocumentOnRecord(con.Id, 'BorderCollie', '.txt');`